### PR TITLE
Fix: when [limit] > [pages count]

### DIFF
--- a/paginathing.js
+++ b/paginathing.js
@@ -17,7 +17,10 @@
     this.startPage = 1;
     this.currentPage = 1;
     this.totalItems = this.el.children().length;
-    this.totalPages = Math.ceil(this.totalItems / this.options.perPage);
+    this.totalPages = Math.max(
+      Math.ceil(this.totalItems / this.options.perPage),
+      options.limitPagination
+    );
     this.container = $('<nav></nav>').addClass(this.options.containerClass);
     this.ul = $('<ul></ul>').addClass(this.options.ulClass);
 
@@ -61,8 +64,8 @@
         if(_self.currentPage <= Math.ceil(limit / 2) + 1) {
           start = 1;
           end = limit;
-        } else if(_self.currentPage + Math.floor(limit / 2) >= _self.totalPages) {
-          start = _self.totalPages - limit;
+        } else if (_self.currentPage + Math.floor(limit / 2) >= _self.totalPages) {
+          start = _self.totalPages + 1 - limit;
           end = _self.totalPages;
         } else {
           start = _self.currentPage - Math.ceil(limit / 2);


### PR DESCRIPTION
When pages limit (5) is greater than pages count (3: 11 elements, 5 items per page):
move to last page (5) from any previous (e.g. 2) - there will be additional redundant items.

**Before** click on page 5:
<img src="https://pp.vk.me/c626529/v626529334/1bee6/A2wBksXDtMk.jpg" alt="before img">

**After** click on page 5:
<img src="https://pp.vk.me/c626529/v626529334/1beed/5o_JwSjrYzo.jpg" alt="after img">